### PR TITLE
Next arrow fixes

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -19,7 +19,3 @@ gulp.task('travis-ci', ['build:website'], () => {
 gulp.task('default', ['clean'], () => {
   gulp.start('build');
 });
-
-gulp.task('watch', ['default'], () => {
-  gulp.watch('src/**/*', ['default']);
-});

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -6,7 +6,6 @@ import del from 'del';
 
 const $ = gulpLoadPlugins();
 
-
 requireDir('./tasks');
 
 gulp.task('clean', del.bind(null, ['.tmp', '.publish', 'dist']));
@@ -19,4 +18,8 @@ gulp.task('travis-ci', ['build:website'], () => {
 
 gulp.task('default', ['clean'], () => {
   gulp.start('build');
+});
+
+gulp.task('watch', ['default'], () => {
+  gulp.watch('src/**/*', ['default']);
 });

--- a/src/scripts/daterangepicker/calendar-header-view.coffee
+++ b/src/scripts/daterangepicker/calendar-header-view.coffee
@@ -51,6 +51,7 @@ class CalendarHeaderView
 
   prevArrowCss: ->
     date = @firstDate().clone().subtract(1, 'millisecond')
+    date = date.endOf('month') if @period() in ['day', 'week']
     {'arrow-hidden': !@currentDate.isWithinBoundaries(date)}
 
   nextArrowCss: ->

--- a/src/scripts/daterangepicker/calendar-header-view.coffee
+++ b/src/scripts/daterangepicker/calendar-header-view.coffee
@@ -54,21 +54,10 @@ class CalendarHeaderView
     {'arrow-hidden': !@currentDate.isWithinBoundaries(date)}
 
   nextArrowCss: ->
-    currentDate = @currentDate().clone()
-
-    # Calculate the _first_ available date in the next period
-    nextPeriodDate =
-      # Day and week calendars are displayed 'monthly' (6 weeks)
-      if @period() in ['day', 'week']
-        currentDate.endOf('month').add(1, 'day')
-      # Month and quarter calendars are displayed yearly
-      else if @period() in ['month', 'quarter']
-        currentDate.endOf('year').add(1, 'day')
-      # Year calendar is displayed in 10 year chunks
-      else if @period() == 'year'
-        @firstYearOfDecade(currentDate).add(10, 'year')
-
-    {'arrow-hidden': !@currentDate.isWithinBoundaries(nextPeriodDate)}
+    [cols, rows] = @period.dimentions()
+    date = @firstDate().clone().add(cols * rows, @period())
+    date = date.startOf('month') if @period() in ['day', 'week']
+    {'arrow-hidden': !@currentDate.isWithinBoundaries(date)}
 
   monthOptions: ->
     minMonth = if @currentDate.minBoundary().isSame(@currentDate(), 'year') then @currentDate.minBoundary().month() else 0

--- a/src/scripts/daterangepicker/calendar-header-view.coffee
+++ b/src/scripts/daterangepicker/calendar-header-view.coffee
@@ -54,11 +54,21 @@ class CalendarHeaderView
     {'arrow-hidden': !@currentDate.isWithinBoundaries(date)}
 
   nextArrowCss: ->
-    [cols, rows] = @period.dimentions()
-    date = @firstDate().clone().add(cols * rows, @period())
-    {'arrow-hidden': !@currentDate.isWithinBoundaries(date)}
+    currentDate = @currentDate().clone()
 
+    # Calculate the _first_ available date in the next period
+    nextPeriodDate =
+      # Day and week calendars are displayed 'monthly' (6 weeks)
+      if @period() in ['day', 'week']
+        currentDate.endOf('month').add(1, 'day')
+      # Month and quarter calendars are displayed yearly
+      else if @period() in ['month', 'quarter']
+        currentDate.endOf('year').add(1, 'day')
+      # Year calendar is displayed in 10 year chunks
+      else if @period() == 'year'
+        @firstYearOfDecade(currentDate).add(10, 'year')
 
+    {'arrow-hidden': !@currentDate.isWithinBoundaries(nextPeriodDate)}
 
   monthOptions: ->
     minMonth = if @currentDate.minBoundary().isSame(@currentDate(), 'year') then @currentDate.minBoundary().month() else 0


### PR DESCRIPTION
Problem: If the max date is within the bottom two "rows" of the calendar (in day/week view) & inside the next month then the next month arrow is hidden.

The dates are still selectable, but are greyed out which is pretty confusing. This change will show the next arrow when at least 1 date is valid in the next month.