### PR TITLE
Made active-color SASS !default

### DIFF
--- a/src/styles/daterangepicker.scss
+++ b/src/styles/daterangepicker.scss
@@ -1,7 +1,7 @@
 $grey-color: #f5f5f5;
 $slightly-darker-grey-color: #eee;
 $dark-grey-color: #bbb;
-$active-color: #08c;
+$active-color: #08c !default;
 $in-range-color: rgba($active-color, 0.1);
 $green-color: #38A551;
 $border-radius: 4px;


### PR DESCRIPTION
Default active color in SASS allows importers to override the color to match site theme. 
I am sure other variables can be made default as well. 

http://sass-lang.com/documentation/file.SASS_REFERENCE.html#Variable_Defaults___default