### PR TITLE
Fix of deprecation warning:

### DIFF
--- a/src/scripts/daterangepicker/util/moment-util.coffee
+++ b/src/scripts/daterangepicker/util/moment-util.coffee
@@ -1,6 +1,6 @@
 class MomentUtil
   @patchCurrentLocale: (obj) ->
-    moment.locale(moment.locale(), obj)
+    moment.updateLocale(moment.locale(), obj)
 
   @setFirstDayOfTheWeek: (dow) ->
     dow = (dow % 7 + 7) % 7


### PR DESCRIPTION
Define Locale Override

Use moment.updateLocale(localeName, config) to change an existing locale.
moment.defineLocale(localeName, config) should only be used for creating a new locale

This deprecation warning is thrown when you attempt to change an existing locale using the defineLocale function. Doing this will result in unexpected behavior related to property inheritance. moment.updateLocale will properly replace properties on an existing locale.